### PR TITLE
Correct homicide rate label

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,7 +406,7 @@
             lifeExpectancy: "Life Expectancy (yrs)",
             medianIncome: "Median Income ($)",
             povertyRate: "Poverty Rate (%)",
-            homicideRate: "Homicide Rate (per /100k)",
+            homicideRate: "Homicide Rate (per 100k)",
             infantMortality: "Infant Mortality (per /1k)",
             foreignBorn: "Foreign-Born (%)"
         };

--- a/script.js
+++ b/script.js
@@ -117,7 +117,7 @@ const statLabels = {
     lifeExpectancy: "Life Expectancy (yrs)",
     medianIncome: "Median Income ($)",
     povertyRate: "Poverty Rate (%)",
-    homicideRate: "Homicide Rate (per /100k)",
+    homicideRate: "Homicide Rate (per 100k)",
     infantMortality: "Infant Mortality (per /1k)",
     foreignBorn: "Foreign-Born (%)"
 };


### PR DESCRIPTION
## Summary
- fix homicide rate stat label text in HTML and JS
- ensure no remaining references to `per /100k`

## Testing
- `grep -n "per /100k" -r .`

------
https://chatgpt.com/codex/tasks/task_e_68408e016c3c83329131ad1a8d2cf5b5